### PR TITLE
Arc-length parametrization

### DIFF
--- a/src/trafficSimulator/core/geometry/cubic_curve.py
+++ b/src/trafficSimulator/core/geometry/cubic_curve.py
@@ -1,4 +1,6 @@
 from .segment import Segment
+from math import sqrt
+from scipy.integrate import quad
 
 CURVE_RESOLUTION = 50
 
@@ -18,8 +20,59 @@ class CubicCurve(Segment):
             y = t**3*self.end[1] + 3*t**2*(1-t)*self.control_2[1] + 3*(1-t)**2*t*self.control_1[1] + (1-t)**3*self.start[1]
             path.append((x, y))
 
-        # Arc-length parametrization
-        # TODO
-
-        # Initialize super
         super().__init__(path)
+        # Arc-length parametrization
+        normalized_path = [(self.compute_x(0), self.compute_y(0))]
+        l = self.get_length()
+        target_l = l/(CURVE_RESOLUTION-1)
+        epsilon = 0.01
+        a = 0
+        for i in range(CURVE_RESOLUTION-1):
+            t = self.find_t(a, target_l, epsilon)
+            new_point = (self.compute_x(t), self.compute_y(t))
+            normalized_path.append(new_point)
+            if t == 1: break
+            else:      a = t
+        super().__init__(normalized_path)
+
+    def compute_x(self, t):
+        return t**3*self.end[0] + 3*t**2*(1-t)*self.control_2[0] + 3*(1-t)**2*t*self.control_1[0] + (1-t)**3*self.start[0]
+    def compute_y(self, t):
+        return t**3*self.end[1] + 3*t**2*(1-t)*self.control_2[1] + 3*(1-t)**2*t*self.control_1[1] + (1-t)**3*self.start[1]
+    def compute_dx(self, t):
+        return 3*t**2*(self.end[0]-3*self.control_2[0]+3*self.control_1[0]-self.start[0]) + 6*t*(self.control_2[0]-2*self.control_1[0]+self.start[0]) + 3*(self.control_1[0]-self.start[0])
+    def compute_dy(self, t):
+        return 3*t**2*(self.end[1]-3*self.control_2[1]+3*self.control_1[1]-self.start[1]) + 6*t*(self.control_2[1]-2*self.control_1[1]+self.start[1]) + 3*(self.control_1[1]-self.start[1])
+    def abs_f(self, t):
+        return sqrt(self.compute_dx(t)**2 + self.compute_dy(t)**2)
+    def find_t(self, a, L, epsilon):
+        """  Finds the t value such that the length of the curve from a to t is L.
+
+        Parameters
+        ----------
+        a : float
+            starting point of the integral
+        L : float
+            target length
+        epsilon : float
+            precision of the approximation
+        """
+        
+        def f(t):
+            integral_value, _ = quad(self.abs_f, a, t)
+            return integral_value
+        
+        # if we cannot reach the target length, return 1 
+        if f(1) < L: return 1
+        
+        lower_bound = a
+        upper_bound = 1
+        mid_point = (lower_bound + upper_bound) / 2.0
+        integ = f(mid_point)
+        while abs(integ-L) > epsilon:
+            if integ < L:       lower_bound = mid_point
+            else:               upper_bound = mid_point
+            mid_point = (lower_bound + upper_bound) / 2.0
+            integ = f(mid_point)
+        return mid_point 
+        

--- a/src/trafficSimulator/core/geometry/cubic_curve.py
+++ b/src/trafficSimulator/core/geometry/cubic_curve.py
@@ -1,6 +1,4 @@
 from .segment import Segment
-from math import sqrt
-from scipy.integrate import quad
 
 CURVE_RESOLUTION = 50
 
@@ -22,18 +20,9 @@ class CubicCurve(Segment):
 
         super().__init__(path)
         # Arc-length parametrization
-        normalized_path = [(self.compute_x(0), self.compute_y(0))]
-        l = self.get_length()
-        target_l = l/(CURVE_RESOLUTION-1)
-        epsilon = 0.01
-        a = 0
-        for i in range(CURVE_RESOLUTION-1):
-            t = self.find_t(a, target_l, epsilon)
-            new_point = (self.compute_x(t), self.compute_y(t))
-            normalized_path.append(new_point)
-            if t == 1: break
-            else:      a = t
+        normalized_path = self.find_normalized_path(CURVE_RESOLUTION)
         super().__init__(normalized_path)
+
 
     def compute_x(self, t):
         return t**3*self.end[0] + 3*t**2*(1-t)*self.control_2[0] + 3*(1-t)**2*t*self.control_1[0] + (1-t)**3*self.start[0]
@@ -43,36 +32,3 @@ class CubicCurve(Segment):
         return 3*t**2*(self.end[0]-3*self.control_2[0]+3*self.control_1[0]-self.start[0]) + 6*t*(self.control_2[0]-2*self.control_1[0]+self.start[0]) + 3*(self.control_1[0]-self.start[0])
     def compute_dy(self, t):
         return 3*t**2*(self.end[1]-3*self.control_2[1]+3*self.control_1[1]-self.start[1]) + 6*t*(self.control_2[1]-2*self.control_1[1]+self.start[1]) + 3*(self.control_1[1]-self.start[1])
-    def abs_f(self, t):
-        return sqrt(self.compute_dx(t)**2 + self.compute_dy(t)**2)
-    def find_t(self, a, L, epsilon):
-        """  Finds the t value such that the length of the curve from a to t is L.
-
-        Parameters
-        ----------
-        a : float
-            starting point of the integral
-        L : float
-            target length
-        epsilon : float
-            precision of the approximation
-        """
-        
-        def f(t):
-            integral_value, _ = quad(self.abs_f, a, t)
-            return integral_value
-        
-        # if we cannot reach the target length, return 1 
-        if f(1) < L: return 1
-        
-        lower_bound = a
-        upper_bound = 1
-        mid_point = (lower_bound + upper_bound) / 2.0
-        integ = f(mid_point)
-        while abs(integ-L) > epsilon:
-            if integ < L:       lower_bound = mid_point
-            else:               upper_bound = mid_point
-            mid_point = (lower_bound + upper_bound) / 2.0
-            integ = f(mid_point)
-        return mid_point 
-        

--- a/src/trafficSimulator/core/geometry/quadratic_curve.py
+++ b/src/trafficSimulator/core/geometry/quadratic_curve.py
@@ -1,5 +1,8 @@
 from .segment import Segment
+from math import sqrt
+from scipy.integrate import quad
 
+PAS = 0.01
 CURVE_RESOLUTION = 50
 
 class QuadraticCurve(Segment):
@@ -17,8 +20,59 @@ class QuadraticCurve(Segment):
             y = t**2*self.end[1] + 2*t*(1-t)*self.control[1] + (1-t)**2*self.start[1]
             path.append((x, y))
 
-        # Arc-length parametrization
-        # TODO
-
-        # Initialize super
         super().__init__(path)
+
+        # Arc-length parametrization
+        normalized_path = [(self.compute_x(0), self.compute_y(0))]
+        l = self.get_length()
+        target_l = l/(CURVE_RESOLUTION-1)
+        epsilon = 0.01
+        a = 0
+        for i in range(CURVE_RESOLUTION-1):
+            t = self.find_t(a, target_l, epsilon)
+            new_point = (self.compute_x(t), self.compute_y(t))
+            normalized_path.append(new_point)
+            if t == 1: break
+            else:      a = t
+        super().__init__(normalized_path)
+
+    def compute_x(self, t):
+        return t**2*self.end[0] + 2*t*(1-t)*self.control[0] + (1-t)**2*self.start[0]
+    def compute_y(self, t):
+        return t**2*self.end[1] + 2*t*(1-t)*self.control[1] + (1-t)**2*self.start[1]
+    def compute_dx(self, t):
+        return 2*t*(self.end[0]-2*self.control[0]+self.start[0]) + 2*(self.control[0]-self.start[0])
+    def compute_dy(self, t):
+        return 2*t*(self.end[1]-2*self.control[1]+self.start[1]) + 2*(self.control[1]-self.start[1])
+    def abs_f(self, t):
+        return sqrt(self.compute_dx(t)**2 + self.compute_dy(t)**2)
+    def find_t(self, a, L, epsilon):
+        """  Finds the t value such that the length of the curve from a to t is L.
+
+        Parameters
+        ----------
+        a : float
+            starting point of the integral
+        L : float
+            target length
+        epsilon : float
+            precision of the approximation
+        """
+        
+        def f(t):
+            integral_value, _ = quad(self.abs_f, a, t)
+            return integral_value
+        
+        # if we cannot reach the target length, return 1 
+        if f(1) < L: return 1
+        
+        lower_bound = a
+        upper_bound = 1
+        mid_point = (lower_bound + upper_bound) / 2.0
+        integ = f(mid_point)
+        while abs(integ-L) > epsilon:
+            if integ < L:       lower_bound = mid_point
+            else:               upper_bound = mid_point
+            mid_point = (lower_bound + upper_bound) / 2.0
+            integ = f(mid_point)
+        return mid_point            

--- a/src/trafficSimulator/core/geometry/quadratic_curve.py
+++ b/src/trafficSimulator/core/geometry/quadratic_curve.py
@@ -1,6 +1,4 @@
 from .segment import Segment
-from math import sqrt
-from scipy.integrate import quad
 
 PAS = 0.01
 CURVE_RESOLUTION = 50
@@ -23,17 +21,7 @@ class QuadraticCurve(Segment):
         super().__init__(path)
 
         # Arc-length parametrization
-        normalized_path = [(self.compute_x(0), self.compute_y(0))]
-        l = self.get_length()
-        target_l = l/(CURVE_RESOLUTION-1)
-        epsilon = 0.01
-        a = 0
-        for i in range(CURVE_RESOLUTION-1):
-            t = self.find_t(a, target_l, epsilon)
-            new_point = (self.compute_x(t), self.compute_y(t))
-            normalized_path.append(new_point)
-            if t == 1: break
-            else:      a = t
+        normalized_path = self.find_normalized_path(CURVE_RESOLUTION)
         super().__init__(normalized_path)
 
     def compute_x(self, t):
@@ -44,35 +32,3 @@ class QuadraticCurve(Segment):
         return 2*t*(self.end[0]-2*self.control[0]+self.start[0]) + 2*(self.control[0]-self.start[0])
     def compute_dy(self, t):
         return 2*t*(self.end[1]-2*self.control[1]+self.start[1]) + 2*(self.control[1]-self.start[1])
-    def abs_f(self, t):
-        return sqrt(self.compute_dx(t)**2 + self.compute_dy(t)**2)
-    def find_t(self, a, L, epsilon):
-        """  Finds the t value such that the length of the curve from a to t is L.
-
-        Parameters
-        ----------
-        a : float
-            starting point of the integral
-        L : float
-            target length
-        epsilon : float
-            precision of the approximation
-        """
-        
-        def f(t):
-            integral_value, _ = quad(self.abs_f, a, t)
-            return integral_value
-        
-        # if we cannot reach the target length, return 1 
-        if f(1) < L: return 1
-        
-        lower_bound = a
-        upper_bound = 1
-        mid_point = (lower_bound + upper_bound) / 2.0
-        integ = f(mid_point)
-        while abs(integ-L) > epsilon:
-            if integ < L:       lower_bound = mid_point
-            else:               upper_bound = mid_point
-            mid_point = (lower_bound + upper_bound) / 2.0
-            integ = f(mid_point)
-        return mid_point            

--- a/src/trafficSimulator/core/geometry/segment.py
+++ b/src/trafficSimulator/core/geometry/segment.py
@@ -2,8 +2,11 @@ from scipy.spatial import distance
 from scipy.interpolate import interp1d
 from collections import deque
 from numpy import arctan2, unwrap, linspace
+from abc import ABC, abstractmethod
+from math import sqrt
+from scipy.integrate import quad
 
-class Segment:
+class Segment(ABC):
     def __init__(self, points):
         self.points = points
         self.vehicles = deque()
@@ -36,3 +39,64 @@ class Segment:
 
     def remove_vehicle(self, veh):
         self.vehicles.remove(veh.id)
+
+    @abstractmethod
+    def compute_x(self, t):
+        pass
+    @abstractmethod
+    def compute_y(self, t):
+        pass
+    @abstractmethod
+    def compute_dx(self, t):
+        pass
+    @abstractmethod
+    def compute_dy(self, t):
+        pass
+
+    def abs_f(self, t):
+        return sqrt(self.compute_dx(t)**2 + self.compute_dy(t)**2)
+    
+    def find_t(self, a, L, epsilon):
+        """  Finds the t value such that the length of the curve from a to t is L.
+
+        Parameters
+        ----------
+        a : float
+            starting point of the integral
+        L : float
+            target length
+        epsilon : float
+            precision of the approximation
+        """
+        
+        def f(t):
+            integral_value, _ = quad(self.abs_f, a, t)
+            return integral_value
+        
+        # if we cannot reach the target length, return 1 
+        if f(1) < L: return 1
+        
+        lower_bound = a
+        upper_bound = 1
+        mid_point = (lower_bound + upper_bound) / 2.0
+        integ = f(mid_point)
+        while abs(integ-L) > epsilon:
+            if integ < L:       lower_bound = mid_point
+            else:               upper_bound = mid_point
+            mid_point = (lower_bound + upper_bound) / 2.0
+            integ = f(mid_point)
+        return mid_point
+    
+    def find_normalized_path(self, CURVE_RESOLUTION=50):
+        normalized_path = [(self.compute_x(0), self.compute_y(0))]
+        l = self.get_length()
+        target_l = l/(CURVE_RESOLUTION-1)
+        epsilon = 0.01
+        a = 0
+        for i in range(CURVE_RESOLUTION-1):
+            t = self.find_t(a, target_l, epsilon)
+            new_point = (self.compute_x(t), self.compute_y(t))
+            normalized_path.append(new_point)
+            if t == 1: break
+            else:      a = t
+        return normalized_path


### PR DESCRIPTION
I have done the arc-length parametrization for both cubic and quadratic Bezier curves. The code is similar for both, so the main part of the code was added to the superclass Segment, where I also declared some abstract methods that were implemented in both Quadratic and Cubic files. 

Our goal is to find a set of points such that the length of the curve between each two consecutive points is ideally equal to TOTAL_LENGTH/#points-1. We define an error tolerance constant epsilon, and use the **quad** method in scipy integrate to compute the integral. The points are then computed using a binary search, as the length function inside the integral is positive.

The method was tested using test2.py and it works well.